### PR TITLE
Don't try to update icons for already destroyed gobs.

### DIFF
--- a/src/haven/Session.java
+++ b/src/haven/Session.java
@@ -460,10 +460,12 @@ public class Session {
 			    int resid = msg.uint16();
 			    Indir<Resource> res;
 			    if(resid == 65535) {
-				oc.icon(gob, null);
+				    if (gob != null)
+					    oc.icon(gob, null);
 			    } else {
-				int ifl = msg.uint8();
-				oc.icon(gob, getres(resid));
+				    int ifl = msg.uint8();
+				    if (gob != null)
+					    oc.icon(gob, getres(resid));
 			    }
 			} else if(type == OD_END) {
 			    break;


### PR DESCRIPTION
Had this happen:

```
Exception in thread "Session reader" java.lang.NullPointerException
    at haven.OCache.icon(OCache.java:314)
    at haven.Session$RWorker.getobjdata(Session.java:466)
    at haven.Session$RWorker.run(Session.java:619)
```

It occurred when fox and badger were fighting and I was moving away from them. The fox died (judging by the sounds) at the same time as it got out of my character's view.
