### PR TITLE
Fix messed up chat message in case of multiple URLs in it

### DIFF
--- a/src/haven/ChatUI.java
+++ b/src/haven/ChatUI.java
@@ -120,7 +120,7 @@ public class ChatUI extends Widget {
 		    p = m.end();
 		    continue;
 		}
-		RichText.Part lead = new RichText.TextPart(text.substring(0, m.start()), attrs);
+		RichText.Part lead = new RichText.TextPart(text.substring(p, m.start()), attrs);
 		if(ret == null) ret = lead; else ret.append(lead);
 		Map<Attribute, Object> na = new HashMap<Attribute, Object>(attrs);
 		na.putAll(urlstyle);


### PR DESCRIPTION
Currently chat messages with multiple URLs (e.g. `http://foo.bar qq http://bar.foo`)  are displayed in the chat window like this:

```
http://foo.barhttp://foo.bar qq http://bar.foo
```
