### PR TITLE
Fix tooltip for a lower half of a buff

### DIFF
--- a/src/haven/Bufflist.java
+++ b/src/haven/Bufflist.java
@@ -37,6 +37,10 @@ public class Bufflist extends Widget {
 	public void move(Coord c, double off);
     }
 
+    public Bufflist() {
+        super(Buff.cframe.sz());
+    }
+
     private void arrange(Widget imm) {
 	int i = 0, rn = 0, x = 0, y = 0, maxh = 0;
 	Coord br = new Coord();


### PR DESCRIPTION
Before only upper half of a buff is sensetive to cursor because a Hidepanel containing Bufflist fit only upper half of a buff. Initialize Bufflist with a buff size to properly resize Hidepanel to be able to get a tooltip from any part of a buff.