### PR TITLE
Fix color selection in BuddyWnd

### DIFF
--- a/src/haven/BuddyWnd.java
+++ b/src/haven/BuddyWnd.java
@@ -227,6 +227,7 @@ public class BuddyWnd extends Widget implements Iterable<BuddyWnd.Buddy> {
 		}, 10, ava.c.y + ava.sz.y + 10);
 	    this.grp = add(new GroupSelector(buddy.group) {
 		    public void changed(int group) {
+			this.group = group;
 			buddy.chgrp(group);
 		    }
 		}, 15, nick.c.y + nick.sz.y + 10);


### PR DESCRIPTION
group field has to be changed to render bounding rect that marks a selected color in an updated position. Otherwise it will be redered in the old one until the client restart.