### PR TITLE
Draw ridges for border tiles

### DIFF
--- a/src/haven/MapSource.java
+++ b/src/haven/MapSource.java
@@ -71,16 +71,16 @@ public interface MapSource {
 		buf.setRGB(c.x, c.y, rgb);
 	    }
 	}
-	for(c.y = 1; c.y < sz.y - 1; c.y++) {
-	    for(c.x = 1; c.x < sz.x - 1; c.x++) {
+	for(c.y = 0; c.y < sz.y; c.y++) {
+	    for(c.x = 0; c.x < sz.x; c.x++) {
 		int t = m.gettile(a.ul.add(c));
 		if(t < 0)
 		    continue;
 		Tiler tl = m.tiler(t);
 		if(tl instanceof haven.resutil.Ridges.RidgeTile) {
 		    if(haven.resutil.Ridges.brokenp(m, a.ul.add(c))) {
-			for(int y = c.y - 1; y <= c.y + 1; y++) {
-			    for(int x = c.x - 1; x <= c.x + 1; x++) {
+			for(int y = Math.max(c.y - 1, 0), ny = Math.min(c.y + 1, sz.y - 1); y <= ny; y++) {
+			    for(int x = Math.max(c.x - 1, 0), nx = Math.min(c.x + 1, sz.x - 1); x <= nx; x++) {
 				Color cc = new Color(buf.getRGB(x, y));
 				buf.setRGB(x, y, Utils.blendcol(cc, Color.BLACK, ((x == c.x) && (y == c.y))?1:0.1).getRGB());
 			    }

--- a/src/haven/resutil/Ridges.java
+++ b/src/haven/resutil/Ridges.java
@@ -709,11 +709,16 @@ public class Ridges extends MapMesh.Hooks {
 	    return(false);
 	double bz = ((RidgeTile)t).breakz() + EPSILON;
 	for(Coord ec : tecs) {
-	    t = map.tiler(map.gettile(tc.add(ec)));
+	    int tile = map.gettile(tc.add(ec));
+	    if(tile < 0)
+		continue;
+	    t = map.tiler(tile);
 	    if(t instanceof RidgeTile)
 		bz = Math.min(bz, ((RidgeTile)t).breakz() + EPSILON);
 	}
 	for(int i = 0; i < 4; i++) {
+	    if(map.getfz(tc.add(tccs[(i + 1) % 4])) == 0.0 || map.getfz(tc.add(tccs[i])) == 0.0)
+		continue;
 	    if(Math.abs(map.getfz(tc.add(tccs[(i + 1) % 4])) - map.getfz(tc.add(tccs[i]))) > bz)
 		return(true);
 	}


### PR DESCRIPTION
Before you may see little holes in the ridge that are aligned with map grid image:
<img width="353" alt="before_border_ridges" src="https://user-images.githubusercontent.com/764107/97927709-cccfb980-1d65-11eb-9338-880cd1c4df74.png">

After there are none:
<img width="351" alt="after_border_ridges" src="https://user-images.githubusercontent.com/764107/97927736-dfe28980-1d65-11eb-83a0-dc81ec055802.png">

Fix is to check all tiles including 0 and sz - 1. Tile is considered to be absent if gettile returns a negative number.