### PR TITLE
Add extended inventory widget

### DIFF
--- a/src/haven/CharWnd.java
+++ b/src/haven/CharWnd.java
@@ -2260,6 +2260,8 @@ public class CharWnd extends Window {
     public void addchild(Widget child, Object... args) {
 	String place = (args[0] instanceof String)?(((String)args[0]).intern()):null;
 	if(place == "study") {
+	    if(child instanceof ExtInventory)
+		((ExtInventory) child).hideExtension();
 	    sattr.add(child, new Coord(width + margin1, offy).add(wbox.btloff()));
 	    Frame.around(sattr, Collections.singletonList(child));
 	    Widget inf = sattr.add(new StudyInfo(new Coord(attrw - UI.scale(150), child.sz.y), child), new Coord(width + margin1 + UI.scale(150), child.c.y).add(wbox.btloff().x, 0));

--- a/src/haven/ExtInventory.java
+++ b/src/haven/ExtInventory.java
@@ -1,0 +1,337 @@
+package haven;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+public class ExtInventory extends Widget implements DTarget {
+    private static final int margin = UI.scale(5);
+    private static final int listw = UI.scale(125);
+    private static final int itemh = UI.scale(20);
+    private static final Color even = new Color(255, 255, 255, 16);
+    private static final Color odd = new Color(255, 255, 255, 32);
+    private static final Color found = new Color(255, 255, 0, 32);
+    private final Inventory inv;
+    private final ItemGroupList list;
+    private final Widget extension;
+    private SortedMap<ItemType, List<GItem>> groups;
+    private boolean groupbyq = true;
+
+    public ExtInventory(Coord sz) {
+	inv = new Inventory(sz);
+	extension = new Widget();
+	Composer composer = new Composer(extension).hmrgn(margin).vmrgn(margin);
+	composer.add(new CheckBox("Group by quality") {
+	    {
+		a = groupbyq;
+	    }
+
+	    @Override
+	    public void set(boolean a) {
+		groupbyq = a;
+		super.set(a);
+	    }
+	});
+	list = new ItemGroupList(listw, (inv.sz.y - composer.y() - margin) / itemh, itemh);
+	composer.add(list);
+	extension.pack();
+	composer = new Composer(this).hmrgn(margin);
+	composer.addr(inv, extension);
+	pack();
+    }
+
+    public void hideExtension() {
+	extension.hide();
+	pack();
+    }
+
+    @Override
+    public boolean drop(Coord cc, Coord ul) {
+	return(inv.drop(cc, ul));
+    }
+
+    @Override
+    public boolean iteminteract(Coord cc, Coord ul) {
+	return(inv.iteminteract(cc, ul));
+    }
+
+    @Override
+    public void addchild(Widget child, Object... args) {
+	inv.addchild(child, args);
+    }
+
+    @Override
+    public void cdestroy(Widget w) {
+	super.cdestroy(w);
+	inv.cdestroy(w);
+    }
+
+    @Override
+    public void wdgmsg(Widget sender, String msg, Object... args) {
+	if(sender == inv) {
+	    super.wdgmsg(this, msg, args);
+	} else {
+	    super.wdgmsg(sender, msg, args);
+	}
+    }
+
+    @Override
+    public void uimsg(String msg, Object... args) {
+	if(msg.equals("sz") || msg.equals("mode")) {
+	    int szx = inv.sz.x;
+	    int szy = inv.sz.y;
+	    inv.uimsg(msg, args);
+	    if((szx != inv.sz.x) || (szy != inv.sz.y)) {
+		extension.move(new Coord(inv.c.x + inv.sz.x + margin, extension.c.y));
+		list.resize(new Coord(list.sz.x, list.sz.y + inv.sz.y - szy));
+		extension.pack();
+		pack();
+	    }
+	} else {
+	    super.uimsg(msg, args);
+	}
+    }
+
+    @Override
+    public boolean mousewheel(Coord c, int amount) {
+	super.mousewheel(c, amount);
+	return(true);
+    }
+
+    @Override
+    public void tick(double dt) {
+	SortedMap<ItemType, List<GItem>> groups = new TreeMap<>();
+	inv.forEachItem((g, w) -> {
+	    try {
+		Double quality = groupbyq ? quality(g) : null;
+		groups.computeIfAbsent(new ItemType(name(g), quality), k -> new ArrayList<>()).add(g);
+	    } catch (Loading ignored) {
+	    }
+	});
+	this.groups = groups;
+	super.tick(dt);
+    }
+
+    private static String name(GItem item) {
+	String name = "???";
+	for(ItemInfo v : item.info()) {
+	    if(v instanceof ItemInfo.Name) {
+		name = ((ItemInfo.Name) v).str.text;
+		break;
+	    }
+	}
+	ItemInfo.Contents contents = findcontents(item.info());
+	if(contents != null) {
+	    String contentName = findname(contents.sub);
+	    if(contentName != null) {
+		name += " " + contentName;
+	    }
+	}
+	return(name);
+    }
+
+    private static Double quality(GItem item) {
+	try {
+	    ItemInfo.Contents contents = findcontents(item.info());
+	    if(contents != null) {
+		Double quality = findquality(contents.sub);
+		if(quality != null) {
+		    return(quality);
+		}
+	    }
+	    return(findquality(item.info()));
+	} catch (NoSuchFieldException | IllegalAccessException e) {
+	    e.printStackTrace();
+	}
+	return(null);
+    }
+
+    private static String findname(List<ItemInfo> info) {
+	for(ItemInfo v : info) {
+	    if(v instanceof ItemInfo.Name) {
+		return(((ItemInfo.Name) v).str.text);
+	    }
+	}
+	return(null);
+    }
+
+    private static Double findquality(List<ItemInfo> info) throws NoSuchFieldException, IllegalAccessException {
+	for(ItemInfo v : info) {
+	    if(v.getClass().getName().equals("Quality")) {
+		return((Double) v.getClass().getField("q").get(v));
+	    }
+	}
+	return(null);
+    }
+
+    private static ItemInfo.Contents findcontents(List<ItemInfo> info) {
+	for(ItemInfo v : info) {
+	    if(v instanceof ItemInfo.Contents) {
+		return((ItemInfo.Contents) v);
+	    }
+	}
+	return(null);
+    }
+
+    private static class ItemType implements Comparable<ItemType> {
+	final String name;
+	final Double quality;
+
+	public ItemType(String name, Double quality) {
+	    this.name = name;
+	    this.quality = quality;
+	}
+
+	@Override
+	public int compareTo(ItemType other) {
+	    int byName = name.compareTo(other.name);
+	    if((byName != 0) || (quality == null) || (other.quality == null)) {
+		return(byName);
+	    }
+	    return(-Double.compare(quality, other.quality));
+	}
+    }
+
+    private static class ItemsGroup extends Widget {
+	private static final BufferedImage def = Resource.loadimg("gfx/hud/mmap/x");
+	private static final Text.Foundry foundry = new Text.Foundry(Text.sans, 12).aa(true);
+	final ItemType type;
+	final List<GItem> items;
+	final WItem sample;
+	private final Text.Line text;
+	private Tex icon;
+
+	public ItemsGroup(ItemType type, List<GItem> items, UI ui) {
+	    super(new Coord(listw, itemh));
+	    this.ui = ui;
+	    this.type = type;
+	    this.items = items;
+	    this.sample = new WItem(items.get(0));
+	    double quality;
+	    if(type.quality == null) {
+		quality = items.stream().map(ExtInventory::quality).filter(Objects::nonNull).reduce(0.0, Double::sum)
+			/ items.stream().map(ExtInventory::quality).filter(Objects::nonNull).count();
+	    } else {
+		quality = type.quality;
+	    }
+	    this.text = foundry.render(String.format("%sq%.1f (%d)", type.quality != null ? "" : "avg ", quality, items.size()));
+	}
+
+	@Override
+	public void draw(GOut g) {
+	    if(icon == null) {
+		try {
+		    GSprite sprite = sample.item.sprite();
+		    if(sprite instanceof GSprite.ImageSprite) {
+			icon = GobIcon.SettingsWindow.Icon.tex(((GSprite.ImageSprite) sprite).image());
+		    } else {
+			Resource.Image image = sample.item.resource().layer(Resource.imgc);
+			if(image == null) {
+			    icon = GobIcon.SettingsWindow.Icon.tex(def);
+			} else {
+			    icon = GobIcon.SettingsWindow.Icon.tex(image.img);
+			}
+		    }
+		} catch (Loading ignored) {
+		}
+	    }
+	    if(icon != null) {
+		g.aimage(icon, new Coord(0, itemh / 2), 0.0, 0.5);
+		g.aimage(text.tex(), new Coord(icon.sz().x + margin, itemh / 2), 0.0, 0.5);
+	    } else {
+		g.aimage(text.tex(), new Coord(margin, itemh / 2), 0.0, 0.5);
+	    }
+	}
+
+	@Override
+	public boolean mousedown(Coord c, int button) {
+	    if(button == 1) {
+		if(ui.modshift) {
+		    if(ui.modctrl) {
+			for(GItem item : items) {
+			    item.wdgmsg("transfer", Inventory.sqsz.div(2), 1);
+			}
+		    } else {
+			items.get(0).wdgmsg("transfer", Inventory.sqsz.div(2), 1);
+		    }
+		} else if(ui.modctrl) {
+		    if(ui.modmeta) {
+			for(GItem item : items) {
+			    item.wdgmsg("drop", Inventory.sqsz.div(2), 1);
+			}
+		    } else {
+			items.get(0).wdgmsg("drop", Inventory.sqsz.div(2), 1);
+		    }
+		} else {
+		    items.get(0).wdgmsg("take", Inventory.sqsz.div(2));
+		}
+		return(true);
+	    } else if(button == 3) {
+		items.get(0).wdgmsg("iact", Inventory.sqsz.div(2), ui.modflags());
+		return(true);
+	    }
+	    return(false);
+	}
+
+	@Override
+	public Object tooltip(Coord c, Widget prev) {
+	    return(sample.tooltip(c, prev));
+	}
+    }
+
+    private class ItemGroupList extends Searchbox<ItemsGroup> {
+	private List<ItemsGroup> groups = Collections.emptyList();
+
+	public ItemGroupList(int w, int h, int itemh) {
+	    super(w, h, itemh);
+	}
+
+	@Override
+	protected boolean searchmatch(int idx, String text) {
+	    return(groups.get(idx).type.name.toLowerCase().contains(text.toLowerCase()));
+	}
+
+	@Override
+	protected ItemsGroup listitem(int i) {
+	    return(groups.get(i));
+	}
+
+	@Override
+	protected int listitems() {
+	    return(groups.size());
+	}
+
+	@Override
+	protected void drawitem(GOut g, ItemsGroup item, int i) {
+	    if(soughtitem(i)) {
+		g.chcolor(found);
+		g.frect(Coord.z, g.sz());
+	    }
+	    g.chcolor(((i % 2) == 0) ? even : odd);
+	    g.frect(Coord.z, g.sz());
+	    g.chcolor();
+	    item.draw(g);
+	}
+
+	@Override
+	public void tick(double dt) {
+	    if(ExtInventory.this.groups == null) {
+		groups = Collections.emptyList();
+	    } else {
+		groups = ExtInventory.this.groups.entrySet().stream()
+			.map(v -> new ItemsGroup(v.getKey(), v.getValue(), ui)).collect(Collectors.toList());
+	    }
+	    super.tick(dt);
+	}
+
+	@Override
+	protected void drawbg(GOut g) {
+	}
+    }
+}

--- a/src/haven/GameUI.java
+++ b/src/haven/GameUI.java
@@ -50,7 +50,7 @@ public class GameUI extends ConsoleHost implements Console.Directory {
     private double msgtime;
     private Window invwnd, equwnd, makewnd, srchwnd, iconwnd;
     private Coord makewndc = Utils.getprefc("makewndc", new Coord(400, 200));
-    public Inventory maininv;
+    public ExtInventory maininv;
     public CharWnd chrwdg;
     public MapWnd mapfile;
     private Widget qqview;
@@ -703,7 +703,7 @@ public class GameUI extends ConsoleHost implements Console.Directory {
 			pack();
 		    }
 		};
-	    invwnd.add(maininv = (Inventory)child, Coord.z);
+	    invwnd.add(maininv = (ExtInventory)child, Coord.z);
 	    invwnd.pack();
 	    invwnd.hide();
 	    add(invwnd, Utils.getprefc("wndc-inv", new Coord(100, 100)));

--- a/src/haven/GobIcon.java
+++ b/src/haven/GobIcon.java
@@ -205,15 +205,18 @@ public class GobIcon extends GAttrib {
 	    private Tex img = null;
 	    public Tex img() {
 		if(this.img == null) {
-		    BufferedImage img = conf.res.loadsaved(Resource.remote()).layer(Resource.imgc).img;
-		    Coord tsz;
-		    if(img.getWidth() > img.getHeight())
-			tsz = new Coord(elh, (elh * img.getHeight()) / img.getWidth());
-		    else
-			tsz = new Coord((elh * img.getWidth()) / img.getHeight(), elh);
-		    this.img = new TexI(PUtils.convolve(img, tsz, filter));
+		    this.img = tex(conf.res.loadsaved(Resource.remote()).layer(Resource.imgc).img);
 		}
 		return(this.img);
+	    }
+
+	    public static Tex tex(BufferedImage img) {
+		Coord tsz;
+		if(img.getWidth() > img.getHeight())
+		    tsz = new Coord(elh, (elh * img.getHeight()) / img.getWidth());
+		else
+		    tsz = new Coord((elh * img.getWidth()) / img.getHeight(), elh);
+		return(new TexI(PUtils.convolve(img, tsz, filter)));
 	    }
 	}
 

--- a/src/haven/Inventory.java
+++ b/src/haven/Inventory.java
@@ -28,6 +28,7 @@ package haven;
 
 import java.util.*;
 import java.awt.image.WritableRaster;
+import java.util.function.BiConsumer;
 
 public class Inventory extends Widget implements DTarget {
     public static final Coord sqsz = UI.scale(new Coord(33, 33));
@@ -58,7 +59,7 @@ public class Inventory extends Widget implements DTarget {
     @RName("inv")
     public static class $_ implements Factory {
 	public Widget create(UI ui, Object[] args) {
-	    return(new Inventory((Coord)args[0]));
+	    return(new ExtInventory((Coord)args[0]));
 	}
     }
 
@@ -79,12 +80,12 @@ public class Inventory extends Widget implements DTarget {
     
     public boolean mousewheel(Coord c, int amount) {
 	if(ui.modshift) {
-	    Inventory minv = getparent(GameUI.class).maininv;
-	    if(minv != this) {
+	    ExtInventory minv = getparent(GameUI.class).maininv;
+	    if(minv != this.parent) {
 		if(amount < 0)
 		    wdgmsg("invxf", minv.wdgid(), 1);
 		else if(amount > 0)
-		    minv.wdgmsg("invxf", this.wdgid(), 1);
+		    minv.wdgmsg("invxf", parent.wdgid(), 1);
 	    }
 	}
 	return(true);
@@ -130,5 +131,9 @@ public class Inventory extends Widget implements DTarget {
 	} else {
 	    super.uimsg(msg, args);
 	}
+    }
+
+    public void forEachItem(BiConsumer<GItem, WItem> consumer) {
+	wmap.forEach(consumer);
     }
 }

--- a/src/haven/Listbox.java
+++ b/src/haven/Listbox.java
@@ -99,8 +99,18 @@ public abstract class Listbox<T> extends ListWidget<T> {
 	T item = itemat(c);
 	if((item == null) && (button == 1))
 	    change(null);
-	else if(item != null)
+	else if(item != null) {
+	    if(item instanceof Widget) {
+		Widget wdg = (Widget) item;
+		if(wdg.visible) {
+		    Coord cc = xlate(wdg.c.addy(c.y / itemh * itemh), true);
+		    if(c.isect(cc, wdg.sz) && wdg.mousedown(c.add(cc.inv()), button)) {
+			return(true);
+		    }
+		}
+	    }
 	    itemclick(item, button);
+	}
 	return(true);
     }
 


### PR DESCRIPTION
Add item list with a check box to group items by quality. Items can be picked and used as in regular inventory plus massive tranfers (Ctrl+Shift+LMB) are applied only to a selected group. Items in the list are sorted by quality. Some features are missing like containers content and number of seeds in a stack is not shown. Still in the current state new inventory is very useful for me and saves a lot of time when need to manipulate with multiple items of different quality or filter, choose items by min/max quality. Consider this more as a feature request with a proof of concept implementation rather than a complete change.

Here are some screenshots:
* Inventory with enabled grouping by quality:
<img width="507" alt="Inventory_enable_group_by_quality" src="https://user-images.githubusercontent.com/764107/106526451-f07dd980-64e5-11eb-8a2e-b442d783dc40.png">

* Inventory with disabled grouping by quality (average quality per item type is shown):
<img width="507" alt="Inventory_disable_group_by_quality" src="https://user-images.githubusercontent.com/764107/106526498-07bcc700-64e6-11eb-94cd-5ef6e874680a.png">

* Inventory with list longer than window can fit:
<img width="505" alt="Inventory_scrollbar" src="https://user-images.githubusercontent.com/764107/106526551-202ce180-64e6-11eb-9a5e-b2e562424f7c.png">

* Belt widget
<img width="319" alt="Belt" src="https://user-images.githubusercontent.com/764107/106526519-11462f00-64e6-11eb-9af0-3594d5d1cc33.png">

* Chicken Coop:
<img width="527" alt="Coop" src="https://user-images.githubusercontent.com/764107/106526595-320e8480-64e6-11eb-9001-ed7b03bddce2.png">

* Search by item name:
<img width="513" alt="Search" src="https://user-images.githubusercontent.com/764107/106527062-ef997780-64e6-11eb-8dfe-8c0bfba764cc.png">
