### PR TITLE
check x and y in haven.Mapfile.Segment.grid()

### DIFF
--- a/src/haven/MapFile.java
+++ b/src/haven/MapFile.java
@@ -1067,7 +1067,7 @@ public class MapFile {
 	}
 
 	public Indir<? extends DataGrid> grid(int lvl, Coord gc) {
-	    if((lvl < 0) || ((gc.x & ((1 << lvl) - 1)) != 0) || ((gc.x & ((1 << lvl) - 1)) != 0))
+	    if((lvl < 0) || ((gc.x & ((1 << lvl) - 1)) != 0) || ((gc.y & ((1 << lvl) - 1)) != 0))
 		throw(new IllegalArgumentException(String.format("%s %s", gc, lvl)));
 	    if(lvl == 0)
 		return(grid(gc));


### PR DESCRIPTION
i assume both x and y is supposed to be checked instead of the x coordinate 2 times? otherwise one of the expressions can just be deleted