### PR TITLE
Fix for minimap zoom on highres mousewheel

### DIFF
--- a/src/haven/MiniMap.java
+++ b/src/haven/MiniMap.java
@@ -864,7 +864,7 @@ public class MiniMap extends Widget {
 	if(amount > 0) {
 	    if(allowzoomout())
 		zoomlevel = Math.min(zoomlevel + 1, dlvl + 1);
-	} else {
+	} else if(amount < 0) {
 	    zoomlevel = Math.max(zoomlevel - 1, 0);
 	}
 	return(true);


### PR DESCRIPTION
`getWheelRotation()` produces `mousewheel` messages with 0 'clicks' on high resolution mouse wheels, like MacBook touchpad. In this case minimap has an incorrect behaviour, as this partial clicks will make minimap view zoom-in, producing a jittering behaviour.
As `zoomlevel` and `scale` are both integers, this is the minimal fix to the described issue.

Alternative solutions which can be considered:
* Do not fire mousewheel event when number of clicks == 0
* Provide an output from `getPreciseWheelRotation()` as an additional argument to `mousewheel` calls to allow widget to decide what to do with high precision wheels. Additionally provide a fractional zoom levels for minimap to allow a more precise zoom behavior for such mouse wheels