### PR TITLE
Fix Inventory Square UI Scaling for high OS Display Scales

### DIFF
--- a/src/haven/Inventory.java
+++ b/src/haven/Inventory.java
@@ -30,7 +30,7 @@ import java.util.*;
 import java.awt.image.WritableRaster;
 
 public class Inventory extends Widget implements DTarget {
-    public static final Coord sqsz = UI.scale(new Coord(32, 32)).add(1, 1);
+    public static final Coord sqsz = UI.scale(new Coord(33, 33));
     public static final Tex invsq;
     public boolean dropul = true;
     public Coord isz;


### PR DESCRIPTION
I managed to reproduce the bug on my 2560x1440 screen using Windows Display Scaling 225% and in-game Interface Scale 2.35.
Other users reported other combinations, usually on 4k displays using Display Scaling and different Interface Scales.

Before:
<img width="531" height="552" alt="1" src="https://github.com/user-attachments/assets/094ae360-ec39-4e11-a36f-92e53b4391da" />

After:
<img width="531" height="552" alt="2" src="https://github.com/user-attachments/assets/8da06e40-adda-4a22-a5a9-69d5f0f38244" />
